### PR TITLE
Email content

### DIFF
--- a/app/views/mailer/reminder_email.html.erb
+++ b/app/views/mailer/reminder_email.html.erb
@@ -10,11 +10,14 @@
             <h3><%= "Hi #{@user.name}" %></h3>
             <!-- Callout Panel -->
             <p class="callout">
-              Please fill
-              <%= link_to "Your hours report", edit_user_timesheet_url(@user, @timesheet) %>
+              Please fill in
+              <%= link_to "your hours report", edit_user_timesheet_url(@user, @timesheet) %>
             </p><!-- /Callout Panel -->
             <p class="lead">
-              <%= "The last day for which you can report hours is #{@report.end_date.in_time_zone('Jerusalem').strftime('%B %d, %Y')}" %>
+              Reporting period:
+              <%= @report.start_date.in_time_zone('Jerusalem').strftime('%B %d, %Y')} %>
+              -
+              <%= @report.end_date.in_time_zone('Jerusalem').strftime('%B %d, %Y')} %>
              </p>
           </td>
         </tr>

--- a/app/views/mailer/reminder_email.html.erb
+++ b/app/views/mailer/reminder_email.html.erb
@@ -14,7 +14,7 @@
               <%= link_to "Your hours report", edit_user_timesheet_url(@user, @timesheet) %>
             </p><!-- /Callout Panel -->
             <p class="lead">
-              <%= "The last day you can fill your hours is #{@report.end_date.in_time_zone('Jerusalem').strftime('%B %d, %Y')}" %>
+              <%= "The last day for which you can report hours is #{@report.end_date.in_time_zone('Jerusalem').strftime('%B %d, %Y')}" %>
              </p>
           </td>
         </tr>


### PR DESCRIPTION
The current HoursReport email is very misleading.  "The last day you can fill your hours is <end_date>"  means that end_date is the **deadline** for reporting my hours.  What you seemingly *intend* to say is "The last day *for which* you can report"

I first changed that, and then decided to change it even further by giving the full date range of the reporting period.   And once we are going with a date *range*, I'm not sure which time format is best: the current verbose one, or the more succinct `2016-12-20`